### PR TITLE
Resolve warnings

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -27,7 +27,6 @@ class CustomTheme {
       iconTheme: IconThemeData(
         color: Colors.white,
       ),
-      brightness: Brightness.light,
       systemOverlayStyle: SystemUiOverlayStyle.light,
     ),
     dividerColor: Colors.black,
@@ -69,7 +68,6 @@ class CustomTheme {
       iconTheme: IconThemeData(
         color: Colors.blue,
       ),
-      brightness: Brightness.dark,
       systemOverlayStyle: SystemUiOverlayStyle.dark,
     ),
     dividerColor: Colors.white,

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -34,7 +34,6 @@ class CustomTheme {
     scaffoldBackgroundColor: Colors.white,
     iconTheme: IconThemeData(color: lightGray),
     bottomAppBarColor: Colors.white,
-    buttonColor: Colors.white,
     // fontFamily: fontFamily,
     textTheme: TextTheme(
       headline1: TextStyle(
@@ -79,7 +78,6 @@ class CustomTheme {
     bottomAppBarColor: Color(0xff1F242B),
     scaffoldBackgroundColor: darkBackgroundColor,
     iconTheme: IconThemeData(color: Colors.white),
-    buttonColor: Colors.black,
     textTheme: TextTheme(
       headline1: TextStyle(
         color: darkTextColor,

--- a/lib/common/bloc/bluetooth_cubit.dart
+++ b/lib/common/bloc/bluetooth_cubit.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:bloc/bloc.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:treehousesble/app/app.dart';
 import 'package:treehousesble/common/bloc/bluetooth_state.dart';
 import 'package:treehousesble/common/constants/app_constants.dart';
 import 'package:treehousesble/common/constants/constant.dart';

--- a/lib/common/bloc/bluetooth_cubit.dart
+++ b/lib/common/bloc/bluetooth_cubit.dart
@@ -115,11 +115,11 @@ class BluetoothCubit extends Cubit<DataState> {
   bool checkIfPi(BluetoothDevice device, bool filterPi) {
     if (filterPi) {
       bool isPi = false;
-      for (int i = 0; i < AppConstants.PI_ADDRESS.length; i++) {
+      for (int i = 0; i < AppConstants.piAddress.length; i++) {
         if (device.id
             .toString()
             .toLowerCase()
-            .startsWith(AppConstants.PI_ADDRESS[i].toLowerCase())) {
+            .startsWith(AppConstants.piAddress[i].toLowerCase())) {
           isPi = true;
           break;
         }

--- a/lib/common/constants/app_constants.dart
+++ b/lib/common/constants/app_constants.dart
@@ -1,5 +1,5 @@
 class AppConstants{
-  static var PI_ADDRESS = [
+  static var piAddress= [
     "B8:27:EB",
     "DC:A6:32",
     "E4:5F:01",

--- a/lib/common/route/route_generator.dart
+++ b/lib/common/route/route_generator.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:treehousesble/common/route/routes.dart';
 import 'package:treehousesble/feature/dashboard/screen/dashboard_page.dart';
-import 'package:treehousesble/feature/dashboard/screen/dashboard_screen.dart';
 import 'package:treehousesble/feature/dashboard/screen/search_rpi_screen.dart';
 import 'package:treehousesble/feature/onboard/ui/screen/landing_page.dart';
 import 'package:treehousesble/feature/onboard/ui/screen/onboard_page.dart';

--- a/lib/common/shared_pref/shared_pref.dart
+++ b/lib/common/shared_pref/shared_pref.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:shared_preferences/shared_preferences.dart';
 
 class SharedPref {

--- a/lib/common/utils/util_functions.dart
+++ b/lib/common/utils/util_functions.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/widgets.dart';
-
 class UtilFunctions {
   /// the int values in `params` have to be stringified otherwise excception
   /// occurs

--- a/lib/feature/dashboard/screen/device_screen.dart
+++ b/lib/feature/dashboard/screen/device_screen.dart
@@ -106,7 +106,7 @@ class _DeviceScreenState extends State<DeviceScreen> {
                   text = snapshot.data.toString().substring(21).toUpperCase();
                   break;
               }
-              return FlatButton(
+              return TextButton(
                   onPressed: onPressed,
                   child: Text(
                     text,

--- a/lib/feature/dashboard/screen/device_screen.dart
+++ b/lib/feature/dashboard/screen/device_screen.dart
@@ -1,6 +1,5 @@
 
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_blue/flutter_blue.dart';

--- a/lib/feature/dashboard/screen/search_rpi_screen.dart
+++ b/lib/feature/dashboard/screen/search_rpi_screen.dart
@@ -4,13 +4,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 import 'package:treehousesble/common/bloc/bluetooth_cubit.dart';
 import 'package:treehousesble/common/bloc/bluetooth_state.dart';
-import 'package:treehousesble/common/navigation/nav.dart';
 import 'package:treehousesble/common/route/routes.dart';
-import 'package:treehousesble/common/widget/page_wrapper.dart';
-import 'package:treehousesble/feature/dashboard/widget/scan_result_tile.dart';
 
 import 'bluetooth_off_screen.dart';
-import 'device_screen.dart';
 
 class SearchRpiScreen extends StatefulWidget {
   @override

--- a/lib/feature/dashboard/screen/search_rpi_screen.dart
+++ b/lib/feature/dashboard/screen/search_rpi_screen.dart
@@ -93,7 +93,6 @@ class _SearchRpiScreenState extends State<SearchRpiScreen> {
                                           },
                                         );
                                       }
-                                      return Text(snapshot.data.toString());
                                     },
                                   ),
                                 ))

--- a/lib/feature/dashboard/screen/search_rpi_screen.dart
+++ b/lib/feature/dashboard/screen/search_rpi_screen.dart
@@ -78,19 +78,27 @@ class _SearchRpiScreenState extends State<SearchRpiScreen> {
                                     builder: (c, snapshot) {
                                       if (snapshot.data ==
                                           BluetoothDeviceState.connected) {
-                                        return ElevatedButton(
-                                          child: Text('OPEN'),
-                                          onPressed: () => context
-                                              .read<BluetoothCubit>()
-                                              .checkDeviceConnected(),
+                                        return SizedBox(
+                                          width: 90,
+                                          height: 40,
+                                          child: ElevatedButton(
+                                            child: Text('OPEN'),
+                                            onPressed: () => context
+                                                .read<BluetoothCubit>()
+                                                .checkDeviceConnected(),
+                                          ),
                                         );
                                       } else {
-                                        return ElevatedButton(
-                                          child: Text('CONNECT'),
-                                          onPressed: () {
-                                            context.read<BluetoothCubit>()
-                                              ..fetchServicesAndConnect(d);
-                                          },
+                                        return SizedBox(
+                                          width: 90,
+                                          height: 40,
+                                          child: ElevatedButton(
+                                            child: Text('CONNECT'),
+                                            onPressed: () {
+                                              context.read<BluetoothCubit>()
+                                                ..fetchServicesAndConnect(d);
+                                            },
+                                          ),
                                         );
                                       }
                                     },

--- a/lib/feature/dashboard/screen/search_rpi_screen.dart
+++ b/lib/feature/dashboard/screen/search_rpi_screen.dart
@@ -78,14 +78,14 @@ class _SearchRpiScreenState extends State<SearchRpiScreen> {
                                     builder: (c, snapshot) {
                                       if (snapshot.data ==
                                           BluetoothDeviceState.connected) {
-                                        return RaisedButton(
+                                        return ElevatedButton(
                                           child: Text('OPEN'),
                                           onPressed: () => context
                                               .read<BluetoothCubit>()
                                               .checkDeviceConnected(),
                                         );
                                       } else {
-                                        return RaisedButton(
+                                        return ElevatedButton(
                                           child: Text('CONNECT'),
                                           onPressed: () {
                                             context.read<BluetoothCubit>()
@@ -106,7 +106,7 @@ class _SearchRpiScreenState extends State<SearchRpiScreen> {
                     );
                   } else if (state is StateError) {
                     return Container(
-                      child: RaisedButton(
+                      child: ElevatedButton(
                         onPressed: () {
                           BlocProvider.of<BluetoothCubit>(context)
                             ..fetchDeviceList(filter);

--- a/lib/feature/dashboard/screen/search_screen.dart
+++ b/lib/feature/dashboard/screen/search_screen.dart
@@ -85,7 +85,7 @@ class _SearchPageState extends State<SearchPage> {
                                   builder: (c, snapshot) {
                                     if (snapshot.data ==
                                         BluetoothDeviceState.connected) {
-                                      return RaisedButton(
+                                      return ElevatedButton(
                                         child: Text('OPEN'),
                                         onPressed: () => Navigator.of(context)
                                             .push(MaterialPageRoute(

--- a/lib/feature/dashboard/screen/search_screen.dart
+++ b/lib/feature/dashboard/screen/search_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_blue/flutter_blue.dart';
 import 'package:treehousesble/feature/dashboard/widget/scan_result_tile.dart';
 

--- a/lib/feature/dashboard/widget/characteristic_tile.dart
+++ b/lib/feature/dashboard/widget/characteristic_tile.dart
@@ -9,7 +9,7 @@ class CharacteristicTile extends StatelessWidget {
   final VoidCallback? onReadPressed;
   final Function(String)? onWritePressed;
   final VoidCallback? onNotificationPressed;
-  TextEditingController inputController = new TextEditingController();
+  final TextEditingController inputController = new TextEditingController();
 
   CharacteristicTile({Key? key,
     required this.characteristic,

--- a/lib/feature/dashboard/widget/characteristic_tile.dart
+++ b/lib/feature/dashboard/widget/characteristic_tile.dart
@@ -25,7 +25,7 @@ class CharacteristicTile extends StatelessWidget {
       stream: characteristic.value,
       initialData: characteristic.lastValue,
       builder: (c, snapshot) {
-        final value = snapshot.data;
+        //final value = snapshot.data;
         print(characteristic.serviceUuid.toString());
         // if(characteristic.serviceUuid.toString() != "6e400001-b5a3-f393-e0a9-e50e24dcca9e"){
         //

--- a/lib/feature/dashboard/widget/scan_result_tile.dart
+++ b/lib/feature/dashboard/widget/scan_result_tile.dart
@@ -88,10 +88,14 @@ class ScanResultTile extends StatelessWidget {
     return ExpansionTile(
       title: _buildTitle(context),
       leading: Text(result.rssi.toString()),
-      trailing: RaisedButton(
+      trailing: ElevatedButton(
         child: Text('CONNECT'),
-        color: Colors.black,
-        textColor: Colors.white,
+        style: ElevatedButton.styleFrom(
+          primary: Colors.black,
+          textStyle: TextStyle(
+            color: Colors.white,
+          ),
+        ),
         onPressed: (result.advertisementData.connectable) ? onTap : null,
       ),
       children: <Widget>[

--- a/lib/feature/onboard/ui/screen/landing_page.dart
+++ b/lib/feature/onboard/ui/screen/landing_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:treehousesble/common/bloc/bluetooth_cubit.dart';
 import 'package:treehousesble/common/bloc/bluetooth_state.dart';
 import 'package:treehousesble/feature/dashboard/screen/search_rpi_screen.dart';
-import 'package:treehousesble/feature/system/screen/system_screen.dart';
 
 import 'onboard_page.dart';
 

--- a/lib/feature/onboard/ui/screen/onboard_page.dart
+++ b/lib/feature/onboard/ui/screen/onboard_page.dart
@@ -4,8 +4,8 @@ import 'package:treehousesble/feature/onboard/ui/widget/onboard_download_widget.
 import '../widget/onboard_widget.dart';
 
 class OnboardPage extends StatelessWidget {
-   PageController _pageController = PageController();
-  int currentIndex = 0;
+  final PageController _pageController = PageController();
+  final int currentIndex = 0;
 
 
   @override

--- a/lib/feature/onboard/ui/widget/onboard_bluetooth_widget.dart
+++ b/lib/feature/onboard/ui/widget/onboard_bluetooth_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:treehousesble/app/theme.dart';
 import 'package:treehousesble/common/route/routes.dart';
 import 'package:treehousesble/common/shared_pref/shared_pref.dart';
 import 'package:treehousesble/common/widget/page_wrapper.dart';

--- a/lib/feature/onboard/ui/widget/onboard_download_widget.dart
+++ b/lib/feature/onboard/ui/widget/onboard_download_widget.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:treehousesble/app/theme.dart';
-import 'package:treehousesble/common/route/routes.dart';
 import 'package:treehousesble/common/shared_pref/shared_pref.dart';
 import 'package:treehousesble/common/widget/page_wrapper.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/lib/feature/onboard/ui/widget/onboard_download_widget.dart
+++ b/lib/feature/onboard/ui/widget/onboard_download_widget.dart
@@ -68,7 +68,7 @@ class _OnboardDownloadWidgetState extends State<OnboardDownloadWidget> {
                   foregroundColor: MaterialStateProperty.all<Color>(Colors.white),
                 ),
                 onPressed: () {
-                  launch('https://treehouses.io/#!pages/download.md');
+                  launchUrl(Uri.parse('https://treehouses.io/#!pages/download.md'));
                 },
                 child: Text('Download'),
               )

--- a/lib/feature/onboard/ui/widget/onboard_widget.dart
+++ b/lib/feature/onboard/ui/widget/onboard_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:treehousesble/app/theme.dart';
-import 'package:treehousesble/common/route/routes.dart';
 import 'package:treehousesble/common/shared_pref/shared_pref.dart';
 import 'package:treehousesble/common/widget/page_wrapper.dart';
 

--- a/lib/feature/onboard/ui/widget/onboard_widget.dart
+++ b/lib/feature/onboard/ui/widget/onboard_widget.dart
@@ -4,7 +4,7 @@ import 'package:treehousesble/common/shared_pref/shared_pref.dart';
 import 'package:treehousesble/common/widget/page_wrapper.dart';
 
 class OnboardWidget extends StatefulWidget {
-  Function() onNext;
+  final Function() onNext;
   OnboardWidget(this.onNext);
 
 

--- a/lib/feature/settings/screen/settings_screen.dart
+++ b/lib/feature/settings/screen/settings_screen.dart
@@ -69,17 +69,17 @@ class _SettingsScreenState extends State<SettingsScreen> {
                           ListTile(
                               title: Text("Contributors"),
                               leading: Icon(Icons.people),
-                              onTap: () => launch("https://github.com/treehouses/flutter-ble-terminal/graphs/contributors")
+                              onTap: () => launchUrl(Uri.parse("https://github.com/treehouses/flutter-ble-terminal/graphs/contributors"))
                           ),
                           ListTile(
                               title: Text("About"),
                               leading: Icon(Icons.info),
-                              onTap: () => launch("https://treehouses.io/#!index.md")
+                              onTap: () => launchUrl(Uri.parse("https://treehouses.io/#!index.md"))
                           ),
                           ListTile(
                               title: Text("Report an Issue"),
                               leading: Icon(Icons.report_problem),
-                              onTap: () => launch("https://github.com/treehouses/flutter-ble-terminal/issues")
+                              onTap: () => launchUrl(Uri.parse("https://github.com/treehouses/flutter-ble-terminal/issues"))
                           )
                         ]
                     )

--- a/lib/feature/status/widget/bluetooth_widget.dart
+++ b/lib/feature/status/widget/bluetooth_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
-import 'package:treehousesble/app/theme.dart';
 
 class BluetoothWidget extends StatelessWidget{
   @override

--- a/lib/feature/status/widget/network_widget.dart
+++ b/lib/feature/status/widget/network_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:treehousesble/app/theme.dart';
 
 class NetworkWidget extends StatelessWidget{
   @override

--- a/lib/feature/terminal/screen/terminal_screen.dart
+++ b/lib/feature/terminal/screen/terminal_screen.dart
@@ -1,8 +1,5 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_blue/flutter_blue.dart';
 import 'package:treehousesble/common/bloc/bluetooth_cubit.dart';
 import 'package:treehousesble/common/bloc/bluetooth_state.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,7 @@
 import 'dart:async';
-import 'dart:math';
 
-import 'package:device_preview/device_preview.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_blue/flutter_blue.dart';
 import 'package:treehousesble/app/app.dart';
-import 'package:treehousesble/app/theme.dart';
 import 'package:treehousesble/common/constants/env.dart';
 
 import 'common/utils/log.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   args:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   crypto:
     dependency: transitive
     description:
@@ -84,7 +84,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   device_frame:
     dependency: transitive
     description:
@@ -159,7 +159,7 @@ packages:
       name: flutter_launcher_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.2"
+    version: "0.9.3"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -209,7 +209,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   image:
     dependency: transitive
     description:
@@ -237,7 +237,7 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.0"
+    version: "4.6.0"
   logger:
     dependency: "direct main"
     description:
@@ -398,7 +398,7 @@ packages:
       name: protobuf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.0"
   provider:
     dependency: transitive
     description:


### PR DESCRIPTION
Clear up Dart Analysis warnings. Warnings include:

- various deprecated codes
- unused imports/variables
- adjustments of variable names and declarations